### PR TITLE
Fix Some warnings and linter issues by clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/ajson/latest/ajson/"
 repository = "https://github.com/importcjj/rust-ajson"
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-MIT"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+autobenches = false
 
 [dependencies]
 regex = "1"

--- a/src/number.rs
+++ b/src/number.rs
@@ -45,7 +45,7 @@ where
 
         while let Some(b) = r.next() {
             match b {
-                b'0'...b'9' => (),
+                b'0'..=b'9' => (),
                 b'.' => float = true,
                 _ => {
                     end = r.position() - 1;
@@ -88,7 +88,7 @@ impl Number {
     pub fn to_u64(&self) -> u64 {
         // println!("{:?}", self);
         match self {
-            Number::F64(s) => f64_to_u64(self.to_f64()).unwrap_or(parse_uint_lossy(s.as_bytes())),
+            Number::F64(s) => f64_to_u64(self.to_f64()).unwrap_or_else(|| parse_uint_lossy(s.as_bytes())),
             Number::I64(s) => s.parse().unwrap_or(ZERO_UINT),
             Number::U64(s) => s.parse().unwrap_or(ZERO_UINT),
         }
@@ -97,7 +97,7 @@ impl Number {
     pub fn to_i64(&self) -> i64 {
         // println!("{:?}", self);
         match self {
-            Number::F64(s) => f64_to_i64(self.to_f64()).unwrap_or(parse_int_lossy(s.as_bytes())),
+            Number::F64(s) => f64_to_i64(self.to_f64()).unwrap_or_else(|| parse_int_lossy(s.as_bytes())),
             Number::I64(s) => s.parse().unwrap_or(ZERO_INT),
             Number::U64(s) => s.parse().unwrap_or(ZERO_INT),
         }
@@ -107,7 +107,7 @@ impl Number {
 fn f64_to_u64(f: f64) -> Option<u64> {
     let u = f as u64;
     match u {
-        MIN_UINT_53...MAX_UINT_53 => Some(u),
+        MIN_UINT_53..=MAX_UINT_53 => Some(u),
         _ => None,
     }
 }
@@ -115,7 +115,7 @@ fn f64_to_u64(f: f64) -> Option<u64> {
 fn f64_to_i64(f: f64) -> Option<i64> {
     let i = f as i64;
     match i {
-        MIN_INT_53...MAX_INT_53 => Some(i),
+        MIN_INT_53..=MAX_INT_53 => Some(i),
         _ => None,
     }
 }
@@ -124,7 +124,7 @@ pub fn parse_uint_lossy(v: &[u8]) -> u64 {
     let mut acc: u64 = 0;
     for b in v {
         match b {
-            b'0'...b'9' => acc = acc * 10 + (*b - 48) as u64,
+            b'0'..=b'9' => acc = acc * 10 + (*b - 48) as u64,
             _ => return acc,
         }
     }
@@ -133,7 +133,7 @@ pub fn parse_uint_lossy(v: &[u8]) -> u64 {
 }
 
 pub fn parse_int_lossy(v: &[u8]) -> i64 {
-    if v.len() == 0 {
+    if v.is_empty() {
         return ZERO_INT;
     }
 
@@ -142,7 +142,7 @@ pub fn parse_int_lossy(v: &[u8]) -> i64 {
 
     for b in v {
         match b {
-            b'0'...b'9' => match sign {
+            b'0'..=b'9' => match sign {
                 true => acc = acc * 10 - (*b - 48) as i64,
                 false => acc = acc * 10 + (*b - 48) as i64,
             },
@@ -150,5 +150,5 @@ pub fn parse_int_lossy(v: &[u8]) -> i64 {
         }
     }
 
-    return acc;
+    acc
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -2,10 +2,10 @@ use path_parser;
 use std::fmt;
 use sub_selector::SubSelector;
 
+use unescape::unescape;
 use util;
 use value::Value;
 use wild;
-use unescape::unescape;
 
 static DEFAULT_NONE_QUERY: Query = Query {
     on: false,
@@ -91,7 +91,7 @@ impl<'a> Path<'a> {
 
     pub fn is_match(&self, key: &[u8]) -> bool {
         let optional_key = if key.contains(&b'\\') {
-              Some(unescape(key))
+            Some(unescape(key))
         } else {
             None
         };
@@ -316,9 +316,9 @@ impl<'a> Query<'a> {
 
             QueryValue::F64(q) => match v {
                 Value::Number(n) => match op.as_str() {
-                    "=" => n.to_f64() == *q,
-                    "==" => n.to_f64() == *q,
-                    "!=" => n.to_f64() != *q,
+                    "=" => (n.to_f64() - *q).abs() < f64::EPSILON,
+                    "==" => (n.to_f64() - *q).abs() < f64::EPSILON,
+                    "!=" => (n.to_f64() - *q).abs() > f64::EPSILON,
                     "<" => n.to_f64() < *q,
                     "<=" => n.to_f64() <= *q,
                     ">" => n.to_f64() > *q,

--- a/src/path_parser.rs
+++ b/src/path_parser.rs
@@ -6,8 +6,8 @@ use sub_selector;
 use number::Number;
 use util;
 
-fn parse_path_from_utf8<'a>(v: &'a [u8]) -> Path<'a> {
-    if v.len() == 0 {
+fn parse_path_from_utf8(v: &[u8]) -> Path {
+    if v.is_empty() {
         return Path::empty();
     }
     // println!("parse path {:?}", String::from_utf8_lossy(v));
@@ -84,8 +84,8 @@ fn parse_path_from_utf8<'a>(v: &'a [u8]) -> Path<'a> {
     current_path
 }
 
-fn parse_query_from_utf8<'a>(v: &'a [u8]) -> (Query<'a>, usize) {
-    if v.len() == 0 {
+fn parse_query_from_utf8(v: &[u8]) -> (Query, usize) {
+    if v.is_empty() {
         return (Query::empty(), 0);
     }
 
@@ -164,7 +164,7 @@ fn parse_query_from_utf8<'a>(v: &'a [u8]) -> (Query<'a>, usize) {
 fn parser_query_value(v: &[u8]) -> (QueryValue, usize) {
     // println!("parse query value {:?}", String::from_utf8_lossy(v));
     let mut reader = reader::RefReader::new(v);
-    while let Some(b) = reader.peek() {
+    if let Some(b) = reader.peek() {
         let value = match b {
             b't' => {
                 reader.read_boolean_value();
@@ -189,7 +189,7 @@ fn parser_query_value(v: &[u8]) -> (QueryValue, usize) {
                 }
                 // Value::Null
             }
-            b'0'...b'9' | b'-' => {
+            b'0'..=b'9' | b'-' => {
                 let n = Number::from(&mut reader);
                 QueryValue::F64(n.to_f64())
             }
@@ -264,12 +264,12 @@ fn parser_query_value(v: &[u8]) -> (QueryValue, usize) {
 //     (q, reader.position())
 // }
 
-pub fn new_path_from_utf8<'a>(v: &'a [u8]) -> Path<'a> {
+pub fn new_path_from_utf8(v: &[u8]) -> Path {
     parse_path_from_utf8(v)
 }
 
 #[allow(dead_code)]
-fn new_query_from_utf8<'a>(v: &'a [u8]) -> Query<'a> {
+fn new_query_from_utf8(v: &[u8]) -> Query {
     let (q, _) = parse_query_from_utf8(v);
     q
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -110,7 +110,7 @@ pub trait ByteReader {
         let start = self.position();
         while let Some(b) = self.next() {
             match b {
-                b'0'...b'9' => (),
+                b'0'..=b'9' => (),
                 b'-' | b'.' => (),
                 _ => return (start, self.position() - 1),
             };
@@ -279,7 +279,7 @@ where
 
         let b = self.buffer[self.offset];
         self.offset += 1;
-        return Some(b);
+        Some(b)
     }
 
     fn peek(&mut self) -> Option<u8> {

--- a/src/sub_selector.rs
+++ b/src/sub_selector.rs
@@ -34,7 +34,7 @@ fn last_of_name(v: &[u8]) -> &[u8] {
     //     }
     // }
 
-    if v.len() == 0 {
+    if v.is_empty() {
         return v;
     }
 
@@ -51,7 +51,7 @@ fn last_of_name(v: &[u8]) -> &[u8] {
         i -= 1;
     }
 
-    return v;
+    v
 }
 
 pub fn parse_selectors_from_utf8<'a>(v: &'a [u8]) -> (Vec<SubSelector<'a>>, usize, bool) {

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -38,21 +38,21 @@ pub fn unescape(v: &[u8]) -> String {
                         // U+D800—U+DBFF (1,024 code points): high surrogates
                         // U+DC00—U+DFFF (1,024 code points): low surrogates
                         match codepoint {
-                            0x0000...0xD7FF => (),
-                            0xD800...0xDBFF => {
+                            0x0000..=0xD7FF => (),
+                            0xD800..=0xDBFF => {
                                 if i + 5 < v.len() && v[i] == b'\\' {
                                     codepoint -= 0xD800;
                                     codepoint <<= 10;
                                     let lower = u8s_to_u32(&v[i + 2..i + 6]);
-                                    if let 0xDC00...0xDFFF = lower {
-                                        codepoint = (codepoint | lower - 0xDC00) + 0x010000;
+                                    if let 0xDC00..=0xDFFF = lower {
+                                        codepoint = (codepoint | (lower - 0xDC00)) + 0x010000;
                                     }
                                     i += 6;
                                 } else {
                                     i += 2;
                                 }
                             }
-                            0xE000...0xFFFF => (),
+                            0xE000..=0xFFFF => (),
                             _ => is_surrogate_pair = false,
                         };
 
@@ -73,13 +73,13 @@ pub fn unescape(v: &[u8]) -> String {
                         }
                         i -= 1;
                     }
-                    b @ _ => {
+                    b => {
                         s.push(b'\\');
                         s.push(b);
                     }
                 }
             }
-            c @ _ => s.push(c),
+            c => s.push(c),
         }
         i += 1;
     }
@@ -93,27 +93,27 @@ fn u8s_to_u32(v: &[u8]) -> u32 {
 
 fn u8_to_u32(b: u8) -> u32 {
     let r = match b {
-        b'0'...b'9' => (b - b'0'),
-        b'a'...b'f' => (b + 10 - b'a'),
-        b'A'...b'F' => (b + 10 - b'A'),
+        b'0'..=b'9' => (b - b'0'),
+        b'a'..=b'f' => (b + 10 - b'a'),
+        b'A'..=b'F' => (b + 10 - b'A'),
         _ => panic!("unexpected byte"),
     };
     r as u32
 }
 
-fn write_codepoint<'a>(codepoint: u32, buffer: &mut Vec<u8>) -> bool {
+fn write_codepoint(codepoint: u32, buffer: &mut Vec<u8>) -> bool {
     match codepoint {
-        0x0000...0x007F => buffer.push(codepoint as u8),
-        0x0080...0x07FF => buffer.extend_from_slice(&[
+        0x0000..=0x007F => buffer.push(codepoint as u8),
+        0x0080..=0x07FF => buffer.extend_from_slice(&[
             (((codepoint >> 6) as u8) & 0x1F) | 0xC0,
             ((codepoint as u8) & 0x3F) | 0x80,
         ]),
-        0x0800...0xFFFF => buffer.extend_from_slice(&[
+        0x0800..=0xFFFF => buffer.extend_from_slice(&[
             (((codepoint >> 12) as u8) & 0x0F) | 0xE0,
             (((codepoint >> 6) as u8) & 0x3F) | 0x80,
             ((codepoint as u8) & 0x3F) | 0x80,
         ]),
-        0x10000...0x10FFFF => buffer.extend_from_slice(&[
+        0x10000..=0x10FFFF => buffer.extend_from_slice(&[
             (((codepoint >> 18) as u8) & 0x07) | 0xF0,
             (((codepoint >> 12) as u8) & 0x3F) | 0x80,
             (((codepoint >> 6) as u8) & 0x3F) | 0x80,

--- a/src/value.rs
+++ b/src/value.rs
@@ -69,45 +69,27 @@ impl Value {
     /// assert!(v.is_string());
     /// ```
     pub fn is_string(&self) -> bool {
-        match self {
-            Value::String(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::String(_))
     }
 
     pub fn is_number(&self) -> bool {
-        match self {
-            Value::Number(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Number(_))
     }
 
     pub fn is_array(&self) -> bool {
-        match self {
-            Value::Array(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Array(_))
     }
 
     pub fn is_object(&self) -> bool {
-        match self {
-            Value::Object(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Object(_))
     }
 
     pub fn is_bool(&self) -> bool {
-        match self {
-            Value::Boolean(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Boolean(_))
     }
 
     pub fn is_null(&self) -> bool {
-        match self {
-            Value::Null => true,
-            _ => false,
-        }
+        matches!(self, Value::Null)
     }
 }
 


### PR DESCRIPTION
Summary of changes:

- Remove deprecate `....` and use `..=` instead (https://stackoverflow.com/questions/49834574/why-it-is-not-possible-to-use-the-syntax-in-expressions)
- Use `matches!`
- Use `is_empty` instead comparing to 0
- Use epsilon while comparing floating numbers
- use if let instead of match for a single arm
- Remove unnecessary lifetime.